### PR TITLE
Add diagnostic protocol intervention log

### DIFF
--- a/diagnostics/intervention_logger.py
+++ b/diagnostics/intervention_logger.py
@@ -1,0 +1,207 @@
+"""
+Lightweight intervention logger for Mercury governance protocols.
+
+Records when existing governance rules fire — claim rejections, scope
+bounding, certainty downgrades, render modifications, legacy restrictions.
+
+This is purely diagnostic. It does NOT alter reasoning logic.
+It does NOT introduce new rules or bypass capabilities.
+
+Usage:
+    logger = InterventionLogger(stage="brief")
+    logger.log_claim_rejected(
+        original_candidate="There is no investment case page on the site",
+        reason="Single-section evidence does not justify site-wide absence claim",
+        protocol_rule="unsupported_site_wide_claim",
+        evidence_ids=["E-010"],
+    )
+    interventions = logger.entries()
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+ALLOWED_PROTOCOL_RULES = {
+    "unsupported_site_wide_claim",
+    "invalid_certainty",
+    "insufficient_evidence",
+    "negative_scope_bounded",
+    "certainty_downgraded",
+    "render_scope_bounded",
+    "certainty_language_adjusted",
+    "validator_rule_failure",
+    "provisional_legacy_restricted",
+}
+
+ALLOWED_ACTIONS = {
+    "claim_rejected",
+    "claim_scope_bounded",
+    "certainty_downgraded",
+    "render_scope_bounded",
+    "render_language_weakened",
+    "legacy_claim_restricted",
+    "artefact_validation_failed",
+}
+
+
+class InterventionLogger:
+    """Append-only log of protocol interventions for a single stage run."""
+
+    def __init__(self, stage: str) -> None:
+        self._stage = stage
+        self._entries: list[dict[str, Any]] = []
+        self._counter = 0
+
+    def _next_id(self) -> str:
+        self._counter += 1
+        return f"PI-{self._counter:03d}"
+
+    def _now(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def _append(
+        self,
+        protocol_rule: str,
+        action: str,
+        reason: str,
+        *,
+        claim_id: str | None = None,
+        original_candidate: str | None = None,
+        final_output: str | None = None,
+        evidence_ids: list[str] | None = None,
+        stage_override: str | None = None,
+    ) -> dict[str, Any]:
+        entry: dict[str, Any] = {
+            "intervention_id": self._next_id(),
+            "stage": stage_override or self._stage,
+            "protocol_rule": protocol_rule,
+            "action": action,
+            "reason": reason,
+            "timestamp": self._now(),
+        }
+        if claim_id is not None:
+            entry["claim_id"] = claim_id
+        if original_candidate is not None:
+            entry["original_candidate"] = original_candidate
+        if final_output is not None:
+            entry["final_output"] = final_output
+        if evidence_ids is not None:
+            entry["evidence_ids"] = evidence_ids
+
+        self._entries.append(entry)
+        return entry
+
+    # ── Convenience methods for common intervention types ───────────
+
+    def log_claim_rejected(
+        self,
+        original_candidate: str,
+        reason: str,
+        protocol_rule: str = "unsupported_site_wide_claim",
+        *,
+        evidence_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Log a claim that was rejected at construction time."""
+        return self._append(
+            protocol_rule=protocol_rule,
+            action="claim_rejected",
+            reason=reason,
+            original_candidate=original_candidate,
+            evidence_ids=evidence_ids,
+        )
+
+    def log_scope_bounded(
+        self,
+        claim_id: str,
+        original_candidate: str,
+        final_output: str,
+        reason: str,
+    ) -> dict[str, Any]:
+        """Log when a claim's scope was narrowed."""
+        return self._append(
+            protocol_rule="negative_scope_bounded",
+            action="claim_scope_bounded",
+            reason=reason,
+            claim_id=claim_id,
+            original_candidate=original_candidate,
+            final_output=final_output,
+        )
+
+    def log_certainty_downgraded(
+        self,
+        claim_id: str,
+        original_candidate: str,
+        final_output: str,
+        reason: str,
+    ) -> dict[str, Any]:
+        """Log when a claim's certainty was downgraded."""
+        return self._append(
+            protocol_rule="certainty_downgraded",
+            action="certainty_downgraded",
+            reason=reason,
+            claim_id=claim_id,
+            original_candidate=original_candidate,
+            final_output=final_output,
+        )
+
+    def log_render_modification(
+        self,
+        claim_id: str,
+        original_candidate: str,
+        final_output: str,
+        reason: str,
+        protocol_rule: str = "render_scope_bounded",
+    ) -> dict[str, Any]:
+        """Log when rendered text was modified to stay within claim scope."""
+        action = (
+            "render_scope_bounded"
+            if protocol_rule == "render_scope_bounded"
+            else "render_language_weakened"
+        )
+        return self._append(
+            protocol_rule=protocol_rule,
+            action=action,
+            reason=reason,
+            claim_id=claim_id,
+            original_candidate=original_candidate,
+            final_output=final_output,
+        )
+
+    def log_legacy_restricted(
+        self,
+        claim_id: str,
+        reason: str,
+    ) -> dict[str, Any]:
+        """Log when a provisional_legacy claim was restricted."""
+        return self._append(
+            protocol_rule="provisional_legacy_restricted",
+            action="legacy_claim_restricted",
+            reason=reason,
+            claim_id=claim_id,
+        )
+
+    def log_validator_failure(
+        self,
+        reason: str,
+        *,
+        claim_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Log when the artefact validator flagged a rule failure."""
+        return self._append(
+            protocol_rule="validator_rule_failure",
+            action="artefact_validation_failed",
+            reason=reason,
+            claim_id=claim_id,
+        )
+
+    # ── Output ─────────────────────────────────────────────────────
+
+    def entries(self) -> list[dict[str, Any]]:
+        """Return a copy of all intervention entries."""
+        return list(self._entries)
+
+    def __len__(self) -> int:
+        return len(self._entries)

--- a/fixtures/invalid_sitewide_claim_artefact.json
+++ b/fixtures/invalid_sitewide_claim_artefact.json
@@ -124,5 +124,38 @@
       "accessed": "2026-03-06",
       "claims_supported": ["C-010"]
     }
+  ],
+  "protocol_interventions": [
+    {
+      "intervention_id": "PI-001",
+      "stage": "brief",
+      "protocol_rule": "unsupported_site_wide_claim",
+      "action": "claim_rejected",
+      "original_candidate": "There is no investment case page on the site",
+      "reason": "Single-section evidence does not justify site-wide absence claim. Evidence covers only IR landing page (1 section). Requires 2+ distinct sections.",
+      "evidence_ids": ["E-010"],
+      "timestamp": "2026-03-06T10:00:00Z"
+    },
+    {
+      "intervention_id": "PI-002",
+      "stage": "brief",
+      "protocol_rule": "unsupported_site_wide_claim",
+      "action": "claim_rejected",
+      "original_candidate": "The company does not have any ESG reporting",
+      "reason": "Site-wide absence claim based on single IR landing page evidence. Scope 'company' is universal.",
+      "evidence_ids": ["E-010"],
+      "timestamp": "2026-03-06T10:01:00Z"
+    },
+    {
+      "intervention_id": "PI-003",
+      "stage": "render",
+      "protocol_rule": "render_scope_bounded",
+      "action": "render_scope_bounded",
+      "claim_id": "C-010",
+      "original_candidate": "There is no investment case page anywhere on the site.",
+      "final_output": "No dedicated investment case page was identified in the reviewed IR pages.",
+      "reason": "Rendered text inflated bounded claim scope to site-wide language",
+      "timestamp": "2026-03-06T10:05:00Z"
+    }
   ]
 }

--- a/fixtures/valid_brief_artefact.json
+++ b/fixtures/valid_brief_artefact.json
@@ -178,6 +178,19 @@
       "claims_supported": ["C-002"]
     }
   ],
+  "protocol_interventions": [
+    {
+      "intervention_id": "PI-001",
+      "stage": "brief",
+      "protocol_rule": "negative_scope_bounded",
+      "action": "claim_scope_bounded",
+      "claim_id": "C-003",
+      "original_candidate": "There is no investment case page on the site",
+      "final_output": "No dedicated investment case page was identified in the reviewed IR pages",
+      "reason": "Claim scope narrowed to match evidence boundary (reviewed IR pages only)",
+      "timestamp": "2026-03-06T10:00:00Z"
+    }
+  ],
   "compliance": {
     "checks_passed": 14,
     "checks_failed": 0,

--- a/schemas/artefact.schema.json
+++ b/schemas/artefact.schema.json
@@ -185,6 +185,11 @@
         }
       }
     },
+    "protocol_interventions": {
+      "type": "array",
+      "items": { "$ref": "intervention.schema.json" },
+      "description": "Diagnostic log of governance protocol interventions. Optional — artefacts without this field remain valid."
+    },
     "compliance": {
       "type": "object",
       "properties": {

--- a/schemas/intervention.schema.json
+++ b/schemas/intervention.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mercury.idx.inc/schemas/intervention.schema.json",
+  "title": "Mercury Protocol Intervention",
+  "description": "Records when a Mercury governance protocol modifies, weakens, or rejects candidate reasoning. Diagnostic metadata only.",
+  "type": "object",
+  "required": [
+    "intervention_id",
+    "stage",
+    "protocol_rule",
+    "action",
+    "reason",
+    "timestamp"
+  ],
+  "properties": {
+    "intervention_id": {
+      "type": "string",
+      "pattern": "^PI-[0-9]{3,}$",
+      "description": "Stable identifier, format PI-NNN."
+    },
+    "stage": {
+      "type": "string",
+      "enum": ["brief", "compete", "sitemap", "meeting", "render"],
+      "description": "Mercury stage where the intervention occurred."
+    },
+    "protocol_rule": {
+      "type": "string",
+      "enum": [
+        "unsupported_site_wide_claim",
+        "invalid_certainty",
+        "insufficient_evidence",
+        "negative_scope_bounded",
+        "certainty_downgraded",
+        "render_scope_bounded",
+        "certainty_language_adjusted",
+        "validator_rule_failure",
+        "provisional_legacy_restricted"
+      ],
+      "description": "The governance rule that triggered the intervention."
+    },
+    "action": {
+      "type": "string",
+      "enum": [
+        "claim_rejected",
+        "claim_scope_bounded",
+        "certainty_downgraded",
+        "render_scope_bounded",
+        "render_language_weakened",
+        "legacy_claim_restricted",
+        "artefact_validation_failed"
+      ],
+      "description": "What the protocol did in response."
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable explanation of why the intervention occurred."
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "ISO 8601 timestamp of the intervention."
+    },
+    "claim_id": {
+      "type": "string",
+      "pattern": "^C-(L?)[0-9]{3,}$",
+      "description": "The claim affected by this intervention, if applicable."
+    },
+    "original_candidate": {
+      "type": "string",
+      "description": "The original text before the protocol intervened."
+    },
+    "final_output": {
+      "type": "string",
+      "description": "The text after the protocol intervened."
+    },
+    "evidence_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Evidence IDs relevant to this intervention."
+    }
+  },
+  "additionalProperties": false
+}

--- a/skills/mercury/references/CLAIM_SCHEMA.md
+++ b/skills/mercury/references/CLAIM_SCHEMA.md
@@ -376,3 +376,86 @@ markdown assembly. A failing artefact cannot proceed to the next stage.
 
 See `schemas/artefact.schema.json`, `schemas/claim.schema.json`, and
 `schemas/rendered_unit.schema.json` for the formal JSON schemas.
+
+---
+
+## 12. Protocol intervention log
+
+The artefact gains an optional `"protocol_interventions": []` array that records
+when Mercury governance protocols intervene — rejecting, bounding, weakening, or
+restricting candidate reasoning.
+
+This is **purely diagnostic**. It does not affect reasoning logic, introduce new
+rules, or create any bypass capability.
+
+### Intervention object schema
+
+```json
+{
+  "intervention_id": "PI-001",
+  "stage": "brief",
+  "protocol_rule": "unsupported_site_wide_claim",
+  "action": "claim_rejected",
+  "original_candidate": "There is no investment case page on the site",
+  "reason": "Single-section evidence does not justify site-wide absence claim",
+  "evidence_ids": ["E-010"],
+  "timestamp": "2026-03-06T14:10:00Z"
+}
+```
+
+### Required fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `intervention_id` | string | Stable identifier, format `PI-NNN` |
+| `stage` | enum | `brief` / `compete` / `sitemap` / `meeting` / `render` |
+| `protocol_rule` | enum | The governance rule that fired |
+| `action` | enum | What the protocol did |
+| `reason` | string | Human-readable explanation |
+| `timestamp` | string | ISO 8601 timestamp |
+
+### Optional fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `claim_id` | string | The claim affected |
+| `original_candidate` | string | Text before intervention |
+| `final_output` | string | Text after intervention |
+| `evidence_ids` | array | Relevant evidence IDs |
+
+### Protocol rules
+
+| Rule | When it fires |
+|------|---------------|
+| `unsupported_site_wide_claim` | Site-wide claim rejected for insufficient evidence |
+| `invalid_certainty` | Certainty value not in allowed set |
+| `insufficient_evidence` | Claim lacks required evidence linkage |
+| `negative_scope_bounded` | Negative claim scope narrowed to match evidence |
+| `certainty_downgraded` | Certainty weakened to match evidence strength |
+| `render_scope_bounded` | Rendered text narrowed to stay within claim scope |
+| `certainty_language_adjusted` | Rendering language weakened to match certainty |
+| `validator_rule_failure` | Artefact validator flagged a violation |
+| `provisional_legacy_restricted` | Legacy claim restricted from high-trust operations |
+
+### Actions
+
+| Action | Meaning |
+|--------|---------|
+| `claim_rejected` | Claim was not added to `claims[]` |
+| `claim_scope_bounded` | Claim scope was narrowed |
+| `certainty_downgraded` | Certainty was reduced |
+| `render_scope_bounded` | Rendered text scope was narrowed |
+| `render_language_weakened` | Rendering language was made less categorical |
+| `legacy_claim_restricted` | Legacy claim blocked from supporting a recommendation |
+| `artefact_validation_failed` | Validator flagged a structural violation |
+
+### Validator rule V014
+
+When `protocol_interventions` is present, the artefact validator checks:
+- Each entry has all required fields
+- Intervention IDs are unique
+- `protocol_rule` and `action` use recognised vocabulary (warning if not)
+
+The field is optional. Artefacts without it remain valid.
+
+See `schemas/intervention.schema.json` for the formal JSON schema.

--- a/tests/test_intervention_log.py
+++ b/tests/test_intervention_log.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Tests for Protocol Intervention Log.
+
+Verifies:
+1. Claim rejection produces intervention log entry
+2. Scope bounding produces intervention log entry
+3. Rendering modification produces intervention log entry
+4. Artefacts remain valid when protocol_interventions is absent
+5. Intervention entries include required fields
+6. Intervention logging does not change claim or finding outputs
+
+Run with:
+    cd mercury
+    python -m unittest tests.test_intervention_log -v
+"""
+
+import json
+import sys
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+# Add paths
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "validators"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "diagnostics"))
+
+from validate_artefact import ArtefactValidator
+from intervention_logger import InterventionLogger
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    with open(FIXTURES / name) as f:
+        return json.load(f)
+
+
+# ── T1: Claim rejection produces intervention entry ────────────────
+
+class TestClaimRejectionIntervention(unittest.TestCase):
+    """T1: Logging a claim rejection produces a valid intervention entry."""
+
+    def test_claim_rejected_entry(self):
+        logger = InterventionLogger(stage="brief")
+        entry = logger.log_claim_rejected(
+            original_candidate="There is no investment case page on the site",
+            reason="Single-section evidence does not justify site-wide absence claim",
+            protocol_rule="unsupported_site_wide_claim",
+            evidence_ids=["E-010"],
+        )
+        self.assertEqual(entry["action"], "claim_rejected")
+        self.assertEqual(entry["protocol_rule"], "unsupported_site_wide_claim")
+        self.assertEqual(entry["stage"], "brief")
+        self.assertIn("PI-", entry["intervention_id"])
+        self.assertIn("E-010", entry["evidence_ids"])
+        self.assertEqual(len(logger), 1)
+
+    def test_multiple_rejections_get_unique_ids(self):
+        logger = InterventionLogger(stage="brief")
+        e1 = logger.log_claim_rejected("Claim A", "Reason A")
+        e2 = logger.log_claim_rejected("Claim B", "Reason B")
+        self.assertNotEqual(e1["intervention_id"], e2["intervention_id"])
+        self.assertEqual(len(logger), 2)
+
+
+# ── T2: Scope bounding produces intervention entry ────────────────
+
+class TestScopeBoundingIntervention(unittest.TestCase):
+    """T2: Logging a scope bounding produces a valid intervention entry."""
+
+    def test_scope_bounded_entry(self):
+        logger = InterventionLogger(stage="brief")
+        entry = logger.log_scope_bounded(
+            claim_id="C-003",
+            original_candidate="There is no investment case page on the site",
+            final_output="No dedicated investment case page was identified in the reviewed IR pages",
+            reason="Scope narrowed to match evidence boundary",
+        )
+        self.assertEqual(entry["action"], "claim_scope_bounded")
+        self.assertEqual(entry["protocol_rule"], "negative_scope_bounded")
+        self.assertEqual(entry["claim_id"], "C-003")
+        self.assertIn("original_candidate", entry)
+        self.assertIn("final_output", entry)
+
+
+# ── T3: Rendering modification produces intervention entry ────────
+
+class TestRenderModificationIntervention(unittest.TestCase):
+    """T3: Logging a render modification produces a valid intervention entry."""
+
+    def test_render_scope_bounded_entry(self):
+        logger = InterventionLogger(stage="render")
+        entry = logger.log_render_modification(
+            claim_id="C-010",
+            original_candidate="There is no investment case page anywhere on the site.",
+            final_output="No dedicated investment case page was identified in the reviewed IR pages.",
+            reason="Rendered text inflated bounded claim scope",
+            protocol_rule="render_scope_bounded",
+        )
+        self.assertEqual(entry["action"], "render_scope_bounded")
+        self.assertEqual(entry["stage"], "render")
+
+    def test_certainty_language_adjusted_entry(self):
+        logger = InterventionLogger(stage="render")
+        entry = logger.log_render_modification(
+            claim_id="C-L001",
+            original_candidate="This definitively confirms job listings exist",
+            final_output="The careers section includes job listings",
+            reason="Provisional legacy claim cannot use high-certainty language",
+            protocol_rule="certainty_language_adjusted",
+        )
+        self.assertEqual(entry["action"], "render_language_weakened")
+        self.assertEqual(entry["protocol_rule"], "certainty_language_adjusted")
+
+
+# ── T4: Artefacts valid without protocol_interventions ─────────────
+
+class TestAbsenceIsValid(unittest.TestCase):
+    """T4: Artefacts without protocol_interventions remain valid."""
+
+    def test_valid_artefact_without_interventions(self):
+        artefact = load_fixture("valid_brief_artefact.json")
+        # Remove protocol_interventions to test absence
+        artefact_no_pi = deepcopy(artefact)
+        artefact_no_pi.pop("protocol_interventions", None)
+        result = ArtefactValidator(artefact_no_pi).validate()
+        self.assertEqual(result["status"], "PASS")
+
+    def test_valid_artefact_with_interventions_still_passes(self):
+        artefact = load_fixture("valid_brief_artefact.json")
+        result = ArtefactValidator(artefact).validate()
+        self.assertEqual(result["status"], "PASS")
+
+
+# ── T5: Intervention entries include required fields ──────────────
+
+class TestInterventionRequiredFields(unittest.TestCase):
+    """T5: Every intervention entry has all required fields."""
+
+    REQUIRED = {"intervention_id", "stage", "protocol_rule", "action", "reason", "timestamp"}
+
+    def test_claim_rejected_has_required_fields(self):
+        logger = InterventionLogger(stage="brief")
+        entry = logger.log_claim_rejected("Candidate text", "Rejection reason")
+        self.assertTrue(self.REQUIRED.issubset(entry.keys()))
+
+    def test_scope_bounded_has_required_fields(self):
+        logger = InterventionLogger(stage="brief")
+        entry = logger.log_scope_bounded("C-001", "Before", "After", "Reason")
+        self.assertTrue(self.REQUIRED.issubset(entry.keys()))
+
+    def test_render_modification_has_required_fields(self):
+        logger = InterventionLogger(stage="render")
+        entry = logger.log_render_modification("C-001", "Before", "After", "Reason")
+        self.assertTrue(self.REQUIRED.issubset(entry.keys()))
+
+    def test_legacy_restricted_has_required_fields(self):
+        logger = InterventionLogger(stage="brief")
+        entry = logger.log_legacy_restricted("C-L001", "Legacy claim restricted")
+        self.assertTrue(self.REQUIRED.issubset(entry.keys()))
+
+    def test_validator_failure_has_required_fields(self):
+        logger = InterventionLogger(stage="brief")
+        entry = logger.log_validator_failure("Artefact failed V006")
+        self.assertTrue(self.REQUIRED.issubset(entry.keys()))
+
+    def test_validator_catches_missing_fields(self):
+        """V014 flags intervention entries with missing required fields."""
+        artefact = load_fixture("valid_brief_artefact.json")
+        artefact["protocol_interventions"] = [
+            {"intervention_id": "PI-999"}  # Missing most required fields
+        ]
+        result = ArtefactValidator(artefact).validate()
+        codes = [e["code"] for e in result["errors"]]
+        self.assertIn("V014_INVALID_INTERVENTION_ENTRY", codes)
+
+    def test_validator_catches_duplicate_ids(self):
+        """V014 flags duplicate intervention IDs."""
+        artefact = load_fixture("valid_brief_artefact.json")
+        entry = {
+            "intervention_id": "PI-001",
+            "stage": "brief",
+            "protocol_rule": "unsupported_site_wide_claim",
+            "action": "claim_rejected",
+            "reason": "Test",
+            "timestamp": "2026-03-06T10:00:00Z",
+        }
+        artefact["protocol_interventions"] = [entry, deepcopy(entry)]
+        result = ArtefactValidator(artefact).validate()
+        codes = [e["code"] for e in result["errors"]]
+        self.assertIn("V014_DUPLICATE_INTERVENTION_ID", codes)
+
+
+# ── T6: Logging does not change claim or finding outputs ──────────
+
+class TestNoSideEffects(unittest.TestCase):
+    """T6: Intervention logging does not alter claims or findings."""
+
+    def test_logger_does_not_modify_claims(self):
+        artefact = load_fixture("valid_brief_artefact.json")
+        claims_before = deepcopy(artefact["claims"])
+        findings_before = deepcopy(artefact["findings"])
+
+        # Simulate logging interventions
+        logger = InterventionLogger(stage="brief")
+        logger.log_claim_rejected("Candidate", "Reason")
+        logger.log_scope_bounded("C-003", "Before", "After", "Reason")
+
+        # Attach to artefact
+        artefact["protocol_interventions"] = logger.entries()
+
+        # Validate — claims and findings must be unchanged
+        self.assertEqual(artefact["claims"], claims_before)
+        self.assertEqual(artefact["findings"], findings_before)
+
+    def test_validator_results_unchanged_by_interventions(self):
+        """Adding valid interventions should not change PASS→FAIL or vice versa."""
+        artefact = load_fixture("valid_brief_artefact.json")
+
+        result_without = ArtefactValidator(deepcopy(artefact)).validate()
+
+        logger = InterventionLogger(stage="brief")
+        logger.log_claim_rejected("Test candidate", "Test reason")
+        logger.log_scope_bounded("C-003", "Before", "After", "Reason")
+        artefact["protocol_interventions"] = logger.entries()
+
+        result_with = ArtefactValidator(artefact).validate()
+
+        self.assertEqual(result_without["status"], result_with["status"])
+        self.assertEqual(result_without["summary"]["errors"], result_with["summary"]["errors"])
+        # Compare full error and warning outputs, not just counts
+        self.assertEqual(result_without["errors"], result_with["errors"])
+        self.assertEqual(result_without["warnings"], result_with["warnings"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validators/rules.py
+++ b/validators/rules.py
@@ -378,6 +378,66 @@ def v013_superseded_rendered(v: "ArtefactValidator") -> None:
                    f"Ensure active claims govern the rendering.")
 
 
+# ── V014: Protocol interventions structural check ────────────────
+
+_ALLOWED_INTERVENTION_RULES = {
+    "unsupported_site_wide_claim", "invalid_certainty", "insufficient_evidence",
+    "negative_scope_bounded", "certainty_downgraded", "render_scope_bounded",
+    "certainty_language_adjusted", "validator_rule_failure",
+    "provisional_legacy_restricted",
+}
+
+_ALLOWED_INTERVENTION_ACTIONS = {
+    "claim_rejected", "claim_scope_bounded", "certainty_downgraded",
+    "render_scope_bounded", "render_language_weakened",
+    "legacy_claim_restricted", "artefact_validation_failed",
+}
+
+_REQUIRED_INTERVENTION_FIELDS = [
+    "intervention_id", "stage", "protocol_rule", "action", "reason", "timestamp",
+]
+
+
+def v014_intervention_log(v: "ArtefactValidator") -> None:
+    interventions = v.artefact.get("protocol_interventions")
+    if interventions is None:
+        return  # Field is optional — absence is valid
+
+    if not isinstance(interventions, list):
+        v.error("V014_INVALID_INTERVENTION_LOG", "(root)",
+                "protocol_interventions must be an array")
+        return
+
+    seen_ids: dict[str, int] = {}
+    for i, entry in enumerate(interventions):
+        pid = entry.get("intervention_id", f"protocol_interventions[{i}]")
+
+        # Required fields
+        for field in _REQUIRED_INTERVENTION_FIELDS:
+            if field not in entry or entry[field] is None or entry[field] == "":
+                v.error("V014_INVALID_INTERVENTION_ENTRY", f"protocol_interventions[{i}]",
+                        f"Intervention {pid} is missing required field '{field}'")
+
+        # Unique IDs
+        if pid in seen_ids:
+            v.error("V014_DUPLICATE_INTERVENTION_ID", f"protocol_interventions[{i}]",
+                    f"Duplicate intervention_id '{pid}' (first at [{seen_ids[pid]}])")
+        else:
+            seen_ids[pid] = i
+
+        # Protocol rule vocabulary
+        rule = entry.get("protocol_rule", "")
+        if rule and rule not in _ALLOWED_INTERVENTION_RULES:
+            v.warn("V014_UNKNOWN_PROTOCOL_RULE", f"protocol_interventions[{i}]",
+                   f"Intervention {pid} has unrecognised protocol_rule '{rule}'")
+
+        # Action vocabulary
+        action = entry.get("action", "")
+        if action and action not in _ALLOWED_INTERVENTION_ACTIONS:
+            v.warn("V014_UNKNOWN_ACTION", f"protocol_interventions[{i}]",
+                   f"Intervention {pid} has unrecognised action '{action}'")
+
+
 # ── Rule registry ──────────────────────────────────────────────────
 
 ALL_RULES = [
@@ -394,4 +454,5 @@ ALL_RULES = [
     v011_rendered_unit_claims,
     v012_render_scope_exceeded,
     v013_superseded_rendered,
+    v014_intervention_log,
 ]


### PR DESCRIPTION
## Summary
- Adds optional `protocol_interventions[]` to artefacts for governance audit trail
- Records when protocols fire: claim rejections, scope bounding, render modifications, legacy restrictions
- Lightweight `InterventionLogger` class (append-only, no side effects)
- V014 validator rule for structural checking when field is present
- Purely diagnostic — no behavioural change to Mercury

## Key files
- `schemas/intervention.schema.json` — Intervention object schema
- `diagnostics/intervention_logger.py` — Append-only logger
- `validators/rules.py` — V014 added
- `skills/mercury/references/CLAIM_SCHEMA.md` — §12 documentation
- `tests/test_intervention_log.py` — 16 passing tests

## Test plan
- [ ] Run `python3 -m unittest tests.test_intervention_log -v` — all 16 pass
- [ ] Run `python3 -m unittest tests.test_validate_artefact -v` — all 22 still pass
- [ ] Verify artefacts without `protocol_interventions` remain valid
- [ ] Merge after claim-ledger PR is merged, then retarget base to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)